### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ⚠️ This tool was created for testing purposes and is not recommended for use in production environments.
 
+<a href="https://glama.ai/mcp/servers/@m-yoshiro/storybook-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@m-yoshiro/storybook-mcp/badge" alt="Storybook Server MCP server" />
+</a>
+
 <!-- This project provides a custom [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol/servers) server that integrates with Storybook to support UI implementation from Figma designs.
 
 It enables AI tools (like Cursor, Claude, or Roo) to query available UI components, retrieve usage examples, and help non-developers (especially designers) collaborate more directly in frontend development workflows. -->


### PR DESCRIPTION
This PR adds a badge for the [Storybook MCP Server](https://glama.ai/mcp/servers/@m-yoshiro/storybook-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@m-yoshiro/storybook-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@m-yoshiro/storybook-mcp/badge" alt="Storybook Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.